### PR TITLE
Elongation Removal for Normalizing Arabic Text

### DIFF
--- a/camel_tools/utils/normalize.py
+++ b/camel_tools/utils/normalize.py
@@ -36,7 +36,7 @@ _ALEF_NORMALIZE_SAFEBW_RE = re.compile(u'[IOLM]')
 _ALEF_NORMALIZE_XMLBW_RE = re.compile(u'[IO{|]')
 _ALEF_NORMALIZE_HSB_RE = re.compile(u'[\u0102\u00c2\u00c4\u0100]')
 _ALEF_NORMALIZE_AR_RE = re.compile(u'[\u0625\u0623\u0671\u0622]')
-
+_ELONGATION_REMOVAL_RE = re.compile(r'(.)\1{2,}')
 
 def normalize_unicode(s, compatibility=True):
     """Normalize Unicode strings into their canonically composed form or
@@ -281,4 +281,4 @@ def remove_elongation(s):
         :obj:`str`: The normalized string.
     """
 
-    return re.sub(r'(.)\1+', r'\1', s)
+    return _ELONGATION_REMOVAL_RE.sub(r'\1', s)

--- a/camel_tools/utils/normalize.py
+++ b/camel_tools/utils/normalize.py
@@ -38,11 +38,11 @@ _ALEF_NORMALIZE_SAFEBW_RE = re.compile(u'[IOLM]')
 _ALEF_NORMALIZE_XMLBW_RE = re.compile(u'[IO{|]')
 _ALEF_NORMALIZE_HSB_RE = re.compile(u'[\u0102\u00c2\u00c4\u0100]')
 _ALEF_NORMALIZE_AR_RE = re.compile(u'[\u0625\u0623\u0671\u0622]')
-_ELONG_AR_RE = re.compile(u'([' + u''.join(AR_CHARSET) + u'])\\1{2,}')
-_ELONG_BW_RE = re.compile(u'([' + u''.join(BW_CHARSET) + u'])\\1{2,}')
-_ELONG_SAFEBW_RE = re.compile(u'([' + u''.join(SAFEBW_CHARSET) + u'])\\1{2,}')
-_ELONG_XMLBW_RE = re.compile(u'([' + u''.join(XMLBW_CHARSET) + u'])\\1{2,}')
-_ELONG_HSB_RE = re.compile(u'([' + u''.join(HSB_CHARSET) + u'])\\1{2,}')
+_REPET_AR_RE = re.compile(u'([' + u''.join(AR_CHARSET) + u'])\\1{2,}')
+_REPET_BW_RE = re.compile(u'([' + u''.join(BW_CHARSET) + u'])\\1{2,}')
+_REPET_SAFEBW_RE = re.compile(u'([' + u''.join(SAFEBW_CHARSET) + u'])\\1{2,}')
+_REPET_XMLBW_RE = re.compile(u'([' + u''.join(XMLBW_CHARSET) + u'])\\1{2,}')
+_REPET_HSB_RE = re.compile(u'([' + u''.join(HSB_CHARSET) + u'])\\1{2,}')
 
 def normalize_unicode(s, compatibility=True):
     """Normalize Unicode strings into their canonically composed form or
@@ -293,11 +293,11 @@ def remove_repetitions_ar(s, policy=1):
     """
 
     if policy == 1:
-        return _ELONG_AR_RE.sub(u'\\1', s)
+        return _REPET_AR_RE.sub(u'\\1', s)
     elif policy == 2:
-        return _ELONG_AR_RE.sub(u'\\1\\1', s)
+        return _REPET_AR_RE.sub(u'\\1\\1', s)
     else:
-        raise ValueError("Policy value should be either 1 or 2!")
+        raise ValueError("Policy value should be either 1 or 2.")
 
 
 def remove_repetitions_bw(s, policy=1):
@@ -317,11 +317,11 @@ def remove_repetitions_bw(s, policy=1):
     """
 
     if policy == 1:
-        return _ELONG_BW_RE.sub(u'\\1', s)
+        return _REPET_BW_RE.sub(u'\\1', s)
     elif policy == 2:
-        return _ELONG_BW_RE.sub(u'\\1\\1', s)
+        return _REPET_BW_RE.sub(u'\\1\\1', s)
     else:
-        raise ValueError("Policy value should be either 1 or 2!")
+        raise ValueError("Policy value should be either 1 or 2.")
 
 def remove_repetitions_safebw(s, policy=1):
     """Reduces the repeated characters (more than two repeated)
@@ -340,11 +340,11 @@ def remove_repetitions_safebw(s, policy=1):
     """
 
     if policy == 1:
-        return _ELONG_SAFEBW_RE.sub(u'\\1', s)
+        return _REPET_SAFEBW_RE.sub(u'\\1', s)
     elif policy == 2:
-        return _ELONG_SAFEBW_RE.sub(u'\\1\\1', s)
+        return _REPET_SAFEBW_RE.sub(u'\\1\\1', s)
     else:
-        raise ValueError("Policy value should be either 1 or 2!")
+        raise ValueError("Policy value should be either 1 or 2.")
 
 
 def remove_repetitions_xmlbw(s, policy=1):
@@ -364,11 +364,11 @@ def remove_repetitions_xmlbw(s, policy=1):
     """
 
     if policy == 1:
-        return _ELONG_XMLBW_RE.sub(u'\\1', s)
+        return _REPET_XMLBW_RE.sub(u'\\1', s)
     elif policy == 2:
-        return _ELONG_XMLBW_RE.sub(u'\\1\\1', s)
+        return _REPET_XMLBW_RE.sub(u'\\1\\1', s)
     else:
-        raise ValueError("Policy value should be either 1 or 2!")
+        raise ValueError("Policy value should be either 1 or 2.")
 
 
 def remove_repetitions_hsb(s, policy=1):
@@ -388,8 +388,8 @@ def remove_repetitions_hsb(s, policy=1):
     """
 
     if policy == 1:
-        return _ELONG_HSB_RE.sub(u'\\1', s)
+        return _REPET_HSB_RE.sub(u'\\1', s)
     elif policy == 2:
-        return _ELONG_HSB_RE.sub(u'\\1\\1', s)
+        return _REPET_HSB_RE.sub(u'\\1\\1', s)
     else:
-        raise ValueError("Policy value should be either 1 or 2!")
+        raise ValueError("Policy value should be either 1 or 2.")

--- a/camel_tools/utils/normalize.py
+++ b/camel_tools/utils/normalize.py
@@ -37,6 +37,7 @@ _ALEF_NORMALIZE_XMLBW_RE = re.compile(u'[IO{|]')
 _ALEF_NORMALIZE_HSB_RE = re.compile(u'[\u0102\u00c2\u00c4\u0100]')
 _ALEF_NORMALIZE_AR_RE = re.compile(u'[\u0625\u0623\u0671\u0622]')
 
+
 def normalize_unicode(s, compatibility=True):
     """Normalize Unicode strings into their canonically composed form or
     (i.e. characters that can be written as a combination of unicode characters

--- a/camel_tools/utils/normalize.py
+++ b/camel_tools/utils/normalize.py
@@ -29,14 +29,20 @@
 
 import re
 import unicodedata
-
+from camel_tools.utils.charsets import AR_CHARSET, BW_CHARSET
+from camel_tools.utils.charsets import SAFEBW_CHARSET, XMLBW_CHARSET
+from camel_tools.utils.charsets import HSB_CHARSET
 
 _ALEF_NORMALIZE_BW_RE = re.compile(u'[<>{|]')
 _ALEF_NORMALIZE_SAFEBW_RE = re.compile(u'[IOLM]')
 _ALEF_NORMALIZE_XMLBW_RE = re.compile(u'[IO{|]')
 _ALEF_NORMALIZE_HSB_RE = re.compile(u'[\u0102\u00c2\u00c4\u0100]')
 _ALEF_NORMALIZE_AR_RE = re.compile(u'[\u0625\u0623\u0671\u0622]')
-_ELONGATION_REMOVAL_RE = re.compile(r'(.)\1{2,}')
+_ELONG_AR_RE = re.compile(u'([' + u''.join(AR_CHARSET) + u'])\\1{2,}')
+_ELONG_BW_RE = re.compile(u'([' + u''.join(BW_CHARSET) + u'])\\1{2,}')
+_ELONG_SAFEBW_RE = re.compile(u'([' + u''.join(SAFEBW_CHARSET) + u'])\\1{2,}')
+_ELONG_XMLBW_RE = re.compile(u'([' + u''.join(XMLBW_CHARSET) + u'])\\1{2,}')
+_ELONG_HSB_RE = re.compile(u'([' + u''.join(HSB_CHARSET) + u'])\\1{2,}')
 
 def normalize_unicode(s, compatibility=True):
     """Normalize Unicode strings into their canonically composed form or
@@ -61,7 +67,7 @@ def normalize_unicode(s, compatibility=True):
 
 
 def normalize_alef_maksura_bw(s):
-    """Normalize all occurences of Alef Maksura characters to a Yeh character
+    """Normalize all occurrences of Alef Maksura characters to a Yeh character
     in a Buckwalter encoded string.
 
     Args:
@@ -75,7 +81,7 @@ def normalize_alef_maksura_bw(s):
 
 
 def normalize_alef_maksura_safebw(s):
-    """Normalize all occurences of Alef Maksura characters to a Yeh character
+    """Normalize all occurrences of Alef Maksura characters to a Yeh character
     in a Safe Buckwalter encoded string.
 
     Args:
@@ -89,7 +95,7 @@ def normalize_alef_maksura_safebw(s):
 
 
 def normalize_alef_maksura_xmlbw(s):
-    """Normalize all occurences of Alef Maksura characters to a Yeh character
+    """Normalize all occurrences of Alef Maksura characters to a Yeh character
     in a XML Buckwalter encoded string.
 
     Args:
@@ -103,7 +109,7 @@ def normalize_alef_maksura_xmlbw(s):
 
 
 def normalize_alef_maksura_hsb(s):
-    """Normalize all occurences of Alef Maksura characters to a Yeh character
+    """Normalize all occurrences of Alef Maksura characters to a Yeh character
     in a Habash-Soudi-Buckwalter encoded string.
 
     Args:
@@ -117,7 +123,7 @@ def normalize_alef_maksura_hsb(s):
 
 
 def normalize_alef_maksura_ar(s):
-    """Normalize all occurences of Alef Maksura characters to a Yeh character
+    """Normalize all occurrences of Alef Maksura characters to a Yeh character
     in an Arabic string.
 
     Args:
@@ -131,7 +137,7 @@ def normalize_alef_maksura_ar(s):
 
 
 def normalize_teh_marbuta_bw(s):
-    """Normalize all occurences of Teh Marbuta characters to a Heh character
+    """Normalize all occurrences of Teh Marbuta characters to a Heh character
     in a Buckwalter encoded string.
 
     Args:
@@ -145,7 +151,7 @@ def normalize_teh_marbuta_bw(s):
 
 
 def normalize_teh_marbuta_safebw(s):
-    """Normalize all occurences of Teh Marbuta characters to a Heh character
+    """Normalize all occurrences of Teh Marbuta characters to a Heh character
     in a Safe Buckwalter encoded string.
 
     Args:
@@ -159,7 +165,7 @@ def normalize_teh_marbuta_safebw(s):
 
 
 def normalize_teh_marbuta_xmlbw(s):
-    """Normalize all occurences of Teh Marbuta characters to a Heh character
+    """Normalize all occurrences of Teh Marbuta characters to a Heh character
     in a XML Buckwalter encoded string.
 
     Args:
@@ -173,7 +179,7 @@ def normalize_teh_marbuta_xmlbw(s):
 
 
 def normalize_teh_marbuta_hsb(s):
-    """Normalize all occurences of Teh Marbuta characters to a Heh character
+    """Normalize all occurrences of Teh Marbuta characters to a Heh character
     in a Habash-Soudi-Buckwalter encoded string.
 
     Args:
@@ -187,7 +193,7 @@ def normalize_teh_marbuta_hsb(s):
 
 
 def normalize_teh_marbuta_ar(s):
-    """Normalize all occurences of Teh Marbuta characters to a Heh character
+    """Normalize all occurrences of Teh Marbuta characters to a Heh character
     in an Arabic string.
 
     Args:
@@ -270,9 +276,9 @@ def normalize_alef_ar(s):
     return _ALEF_NORMALIZE_AR_RE.sub(u'\u0627', s)
 
 
-def remove_elongation(s):
-    """Removes the elongated (duplicated) characters from an 
-    Arabic String.
+def remove_elongation_ar(s):
+    """Removes the elongated characters (more than two repeated) 
+    from an Arabic String.
 
     Args:
         s (:obj:`str`): The string to be normalized.
@@ -281,4 +287,60 @@ def remove_elongation(s):
         :obj:`str`: The normalized string.
     """
 
-    return _ELONGATION_REMOVAL_RE.sub(r'\1', s)
+    return _ELONG_AR_RE.sub('\\1', s)
+
+
+def remove_elongation_bw(s):
+    """Removes the elongated characters (more than two repeated) 
+    from a Buckwalter encoded string.
+
+    Args:
+        s (:obj:`str`): The string to be normalized.
+
+    Returns:
+        :obj:`str`: The normalized string.
+    """
+
+    return _ELONG_BW_RE.sub('\\1', s)
+
+
+def remove_elongation_safebw(s):
+    """Removes the elongated characters (more than two repeated) 
+    from a Safe Buckwalter encoded string.
+
+    Args:
+        s (:obj:`str`): The string to be normalized.
+
+    Returns:
+        :obj:`str`: The normalized string.
+    """
+
+    return _ELONG_SAFEBW_RE.sub('\\1', s)
+
+
+def remove_elongation_xmlbw(s):
+    """Removes the elongated characters (more than two repeated) 
+    from an XML Buckwalter encoded string.
+
+    Args:
+        s (:obj:`str`): The string to be normalized.
+
+    Returns:
+        :obj:`str`: The normalized string.
+    """
+
+    return _ELONG_XMLBW_RE.sub('\\1', s)
+
+
+def remove_elongation_hsb(s):
+    """Removes the elongated characters (more than two repeated) 
+    from an Habash-Soudi-Buckwalter encoded string.
+
+    Args:
+        s (:obj:`str`): The string to be normalized.
+
+    Returns:
+        :obj:`str`: The normalized string.
+    """
+
+    return _ELONG_HSB_RE.sub('\\1', s)

--- a/camel_tools/utils/normalize.py
+++ b/camel_tools/utils/normalize.py
@@ -276,9 +276,9 @@ def normalize_alef_ar(s):
     return _ALEF_NORMALIZE_AR_RE.sub(u'\u0627', s)
 
 
-def remove_elongation_ar(s):
-    """Removes the elongated characters (more than two repeated) 
-    from an Arabic String.
+def remove_repetitions_ar(s):
+    """Removes the repeated characters (more than two repeated) 
+    from an Arabic string.
 
     Args:
         s (:obj:`str`): The string to be normalized.
@@ -290,8 +290,8 @@ def remove_elongation_ar(s):
     return _ELONG_AR_RE.sub('\\1', s)
 
 
-def remove_elongation_bw(s):
-    """Removes the elongated characters (more than two repeated) 
+def remove_repetitions_bw(s):
+    """Removes the repeated characters (more than two repeated) 
     from a Buckwalter encoded string.
 
     Args:
@@ -304,8 +304,8 @@ def remove_elongation_bw(s):
     return _ELONG_BW_RE.sub('\\1', s)
 
 
-def remove_elongation_safebw(s):
-    """Removes the elongated characters (more than two repeated) 
+def remove_repetitions_safebw(s):
+    """Removes the repeated characters (more than two repeated) 
     from a Safe Buckwalter encoded string.
 
     Args:
@@ -318,8 +318,8 @@ def remove_elongation_safebw(s):
     return _ELONG_SAFEBW_RE.sub('\\1', s)
 
 
-def remove_elongation_xmlbw(s):
-    """Removes the elongated characters (more than two repeated) 
+def remove_repetitions_xmlbw(s):
+    """Removes the repeated characters (more than two repeated) 
     from an XML Buckwalter encoded string.
 
     Args:
@@ -332,8 +332,8 @@ def remove_elongation_xmlbw(s):
     return _ELONG_XMLBW_RE.sub('\\1', s)
 
 
-def remove_elongation_hsb(s):
-    """Removes the elongated characters (more than two repeated) 
+def remove_repetitions_hsb(s):
+    """Removes the repeated characters (more than two repeated) 
     from an Habash-Soudi-Buckwalter encoded string.
 
     Args:

--- a/camel_tools/utils/normalize.py
+++ b/camel_tools/utils/normalize.py
@@ -37,7 +37,6 @@ _ALEF_NORMALIZE_XMLBW_RE = re.compile(u'[IO{|]')
 _ALEF_NORMALIZE_HSB_RE = re.compile(u'[\u0102\u00c2\u00c4\u0100]')
 _ALEF_NORMALIZE_AR_RE = re.compile(u'[\u0625\u0623\u0671\u0622]')
 
-
 def normalize_unicode(s, compatibility=True):
     """Normalize Unicode strings into their canonically composed form or
     (i.e. characters that can be written as a combination of unicode characters
@@ -268,3 +267,17 @@ def normalize_alef_ar(s):
     """
 
     return _ALEF_NORMALIZE_AR_RE.sub(u'\u0627', s)
+
+
+def remove_elongation(s):
+    """Removes the elongated (duplicated) characters from an 
+    Arabic String.
+
+    Args:
+        s (:obj:`str`): The string to be normalized.
+
+    Returns:
+        :obj:`str`: The normalized string.
+    """
+
+    return re.sub(r'(.)\1+', r'\1', s)

--- a/camel_tools/utils/normalize.py
+++ b/camel_tools/utils/normalize.py
@@ -276,71 +276,120 @@ def normalize_alef_ar(s):
     return _ALEF_NORMALIZE_AR_RE.sub(u'\u0627', s)
 
 
-def remove_repetitions_ar(s):
-    """Removes the repeated characters (more than two repeated) 
-    from an Arabic string.
+def remove_repetitions_ar(s, policy=1):
+    """Reduces the repeated characters (more than two repeated) 
+    from an Arabic string to one or two characters based on the 
+    optional specified policy.
 
     Args:
         s (:obj:`str`): The string to be normalized.
+        policy (:obj:`int`, optional):
+            The reduction policy. If policy=`1` the repeated characters will
+            be reduced to `1` character. If policy=`2` the repeated characters
+            will be reduced to `2` characters. Defaults to `1`.
 
     Returns:
         :obj:`str`: The normalized string.
     """
 
-    return _ELONG_AR_RE.sub('\\1', s)
+    if policy == 1:
+        return _ELONG_AR_RE.sub(u'\\1', s)
+    elif policy == 2:
+        return _ELONG_AR_RE.sub(u'\\1\\1', s)
+    else:
+        raise ValueError("Policy value should be either 1 or 2!")
 
 
-def remove_repetitions_bw(s):
-    """Removes the repeated characters (more than two repeated) 
-    from a Buckwalter encoded string.
+def remove_repetitions_bw(s, policy=1):
+    """Reduces the repeated characters (more than two repeated) 
+    from a Buckwalter encoded string to one or two characters based on the 
+    optional specified policy.
 
     Args:
         s (:obj:`str`): The string to be normalized.
+        policy (:obj:`int`, optional):
+            The reduction policy. If policy=`1` the repeated characters will
+            be reduced to `1` character. If policy=`2` the repeated characters
+            will be reduced to `2` characters. Defaults to `1`.
 
     Returns:
         :obj:`str`: The normalized string.
     """
 
-    return _ELONG_BW_RE.sub('\\1', s)
+    if policy == 1:
+        return _ELONG_BW_RE.sub(u'\\1', s)
+    elif policy == 2:
+        return _ELONG_BW_RE.sub(u'\\1\\1', s)
+    else:
+        raise ValueError("Policy value should be either 1 or 2!")
 
-
-def remove_repetitions_safebw(s):
-    """Removes the repeated characters (more than two repeated) 
-    from a Safe Buckwalter encoded string.
+def remove_repetitions_safebw(s, policy=1):
+    """Reduces the repeated characters (more than two repeated)
+    from a Safe Buckwalter encoded string to one or two characters based on 
+    the optional specified policy.
 
     Args:
         s (:obj:`str`): The string to be normalized.
+        policy (:obj:`int`, optional):
+            The reduction policy. If policy=`1` the repeated characters will
+            be reduced to `1` character. If policy=`2` the repeated characters
+            will be reduced to `2` characters. Defaults to `1`.
 
     Returns:
         :obj:`str`: The normalized string.
     """
 
-    return _ELONG_SAFEBW_RE.sub('\\1', s)
+    if policy == 1:
+        return _ELONG_SAFEBW_RE.sub(u'\\1', s)
+    elif policy == 2:
+        return _ELONG_SAFEBW_RE.sub(u'\\1\\1', s)
+    else:
+        raise ValueError("Policy value should be either 1 or 2!")
 
 
-def remove_repetitions_xmlbw(s):
-    """Removes the repeated characters (more than two repeated) 
-    from an XML Buckwalter encoded string.
+def remove_repetitions_xmlbw(s, policy=1):
+    """Reduces the repeated characters (more than two repeated) 
+    from an XML Buckwalter encoded string to one or two characters based on 
+    the optional specified policy.
 
     Args:
         s (:obj:`str`): The string to be normalized.
+        policy (:obj:`int`, optional):
+            The reduction policy. If policy=`1` the repeated characters will
+            be reduced to `1` character. If policy=`2` the repeated characters
+            will be reduced to `2` characters. Defaults to `1`.
 
     Returns:
         :obj:`str`: The normalized string.
     """
 
-    return _ELONG_XMLBW_RE.sub('\\1', s)
+    if policy == 1:
+        return _ELONG_XMLBW_RE.sub(u'\\1', s)
+    elif policy == 2:
+        return _ELONG_XMLBW_RE.sub(u'\\1\\1', s)
+    else:
+        raise ValueError("Policy value should be either 1 or 2!")
 
 
-def remove_repetitions_hsb(s):
+def remove_repetitions_hsb(s, policy=1):
     """Removes the repeated characters (more than two repeated) 
-    from an Habash-Soudi-Buckwalter encoded string.
+    from an Habash-Soudi-Buckwalter encoded string to one or two characters 
+    based on the optional specified policy.
 
     Args:
         s (:obj:`str`): The string to be normalized.
+        policy (:obj:`int`, optional):
+            The reduction policy. If policy=`1` the repeated characters will
+            be reduced to `1` character. If policy=`2` the repeated characters
+            will be reduced to `2` characters. Defaults to `1`.
 
     Returns:
         :obj:`str`: The normalized string.
     """
 
-    return _ELONG_HSB_RE.sub('\\1', s)
+    if policy == 1:
+        return _ELONG_HSB_RE.sub(u'\\1', s)
+    elif policy == 2:
+        return _ELONG_HSB_RE.sub(u'\\1\\1', s)
+    else:
+        raise ValueError("Policy value should be either 1 or 2!")

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+# MIT License
+#
+# Copyright 2018-2019 New York University Abu Dhabi
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Tests for camel_tools.utils.normalize
+"""
+
+
+from camel_tools.utils.normalize import remove_elongation_ar
+
+
+class TestElongationRemoval(object):
+    """Test class for the elongation removal functions
+    """
+
+    def test_remove_elongation_ar_empty_str(self):
+    	"""Test that an empty string will return an empty string
+    	"""
+
+    	assert remove_elongation_ar('') == ''
+
+
+    def test_remove_elongation_ar_no_dups(self):
+    	"""Test that two consecutive duplicates will not be removed
+    	from the string.
+    	"""
+
+    	assert remove_elongation_ar('\u0645\u0645\u064a\u0632') == '\u0645\u0645\u064a\u0632'
+
+
+    def test_remove_elongation_ar_start(self):
+    	"""Test that more than two consecutive duplicates at the beginning
+    	will be removed from the string.
+    	"""
+
+    	assert remove_elongation_ar('\u0643\u0643\u0643\u062a\u064a\u0631') == '\u0643\u062a\u064a\u0631'
+
+
+    def test_remove_elongation_ar_middle(self):
+    	"""Test that more than two consecutive duplicates at the middle
+    	will be removed from the string.
+    	"""
+
+    	assert remove_elongation_ar('\u0643\u062a\u064a\u064a\u064a\u0631') == '\u0643\u062a\u064a\u0631'
+
+
+    def test_remove_elongation_ar_end(self):
+    	"""Test that more than two consecutive duplicates at the end
+    	will be removed from the string.
+    	"""
+
+    	assert remove_elongation_ar('\u0643\u062a\u064a\u0631\u0631\u0631') == '\u0643\u062a\u064a\u0631'


### PR DESCRIPTION
I was normalizing some data and I think that having an elongation removal functionality as part of the `utils.normalize` could be useful :smile: and I added this in `remove_elongation()` 