### PR TITLE
Sentiment Analyzer Factorization 

### DIFF
--- a/camel_tools/sentiment/__init__.py
+++ b/camel_tools/sentiment/__init__.py
@@ -36,6 +36,8 @@ from camel_tools.data import get_dataset_path
 
 
 _DEFAULT_DATA_PATH = get_dataset_path('SentimentAnalysis')
+_LABELS = ('positive', 'negative', 'neutral')
+
 
 class SentimentAnalyzer:
     """A class for running a fine-tuned sentiment analysis model to predict
@@ -73,7 +75,7 @@ class SentimentAnalyzer:
             :obj:`list` of :obj:`str`: List of sentiment labels.
         """
 
-        return list(self.labels_map.values())
+        return list(_LABELS)
 
     def predict_sentence(self, sentence):
         """Predict the sentiment label of a single sentence.

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ INSTALL_REQUIRES = [
     'kenlm @ https://github.com/kpu/kenlm/archive/master.zip',
     'dill',
     'torch>=1.3',
-    'transformers==2.5.1',
+    'transformers==3.0.2',
 ]
 
 setup(


### PR DESCRIPTION
After fixing the config of the fine-tuned models, we're able to read the labels mapping from the config file directly. So there isn't a need to create a mapping when a sentiment analyzer object is created. I also took out the unnecessary comments as well as the duplicated code in `predict()`. I also bumped up the transformers version in the setup.py file. 