### PR TITLE
New tokenization scheme added: `bwtok`

### DIFF
--- a/camel_tools/morphology/analyzer.py
+++ b/camel_tools/morphology/analyzer.py
@@ -61,7 +61,7 @@ _IS_AR_RE = re.compile(u'^[' + re.escape(u''.join(AR_CHARSET)) + u']+$')
 _NOAN_RE = re.compile(u'NOAN')
 
 _COPY_FEATS = frozenset(['gloss', 'atbtok', 'atbseg', 'd1tok', 'd1seg',
-                         'd2tok', 'd2seg', 'd3tok', 'd3seg'])
+                         'd2tok', 'd2seg', 'd3tok', 'd3seg', 'bwtok'])
 
 _UNDEFINED_LEX_FEATS = frozenset(['root', 'pattern', 'caphi'])
 

--- a/camel_tools/morphology/reinflector.py
+++ b/camel_tools/morphology/reinflector.py
@@ -44,7 +44,7 @@ _CLITIC_FEATS = frozenset(['enc0', 'prc0', 'prc1', 'prc2', 'prc3'])
 _IGNORED_FEATS = frozenset(['diac', 'lex', 'bw', 'gloss', 'source', 'stem',
                             'stemcat', 'lmm', 'dediac', 'caphi', 'catib6',
                             'ud', 'd3seg', 'atbseg', 'd2seg', 'd1seg', 'd1tok',
-                            'd2tok', 'atbtok', 'd3tok', 'root', 'pattern',
+                            'd2tok', 'atbtok', 'd3tok', 'bwtok', 'root', 'pattern',
                             'freq', 'pos_logprob', 'lex_logprob',
                             'pos_lex_logprob', 'stemgloss'])
 _SPECIFIED_FEATS = frozenset(['form_gen', 'form_num'])

--- a/camel_tools/morphology/utils.py
+++ b/camel_tools/morphology/utils.py
@@ -32,7 +32,7 @@ import re
 _JOIN_FEATS = frozenset(['gloss', 'bw'])
 _CONCAT_FEATS = frozenset(['diac', 'pattern', 'caphi', 'catib6', 'ud'])
 _CONCAT_FEATS_NONE = frozenset(['d3tok', 'd3seg', 'atbseg', 'd2seg', 'd1seg',
-                                'd1tok', 'd2tok', 'atbtok'])
+                                'd1tok', 'd2tok', 'atbtok', 'bwtok'])
 _LOGPROB_FEATS = frozenset(['pos_logprob', 'lex_logprob', 'pos_lex_logprob'])
 
 # Tokenization schemes to which Sun letters and Fatha after Alif rewrite

--- a/camel_tools/tagger/default.py
+++ b/camel_tools/tagger/default.py
@@ -84,6 +84,7 @@ _FEAT_ACTIONS = {
     'prc3': _tag_none,
     'atbtok': _tag_passthrough,
     'atbseg': _tag_passthrough,
+    'bwtok': _tag_passthrough,
     'd1tok': _tag_passthrough,
     'd1seg': _tag_passthrough,
     'd2tok': _tag_passthrough,

--- a/camel_tools/tokenizers/morphological.py
+++ b/camel_tools/tokenizers/morphological.py
@@ -93,7 +93,7 @@ class MorphologicalTokenizer(object):
                     tok = disambig_word.word
                     result.append(self._diacf(tok))
                 elif self._split:
-                    result.extend(self._diacf(t) for t in [tok.split('_')])
+                    result.extend(self._diacf(t) for t in tok.split('_'))
                 else:
                     result.append(self._diacf(tok))
 

--- a/camel_tools/tokenizers/morphological.py
+++ b/camel_tools/tokenizers/morphological.py
@@ -74,6 +74,10 @@ class MorphologicalTokenizer(object):
         diac (:obj:`bool`, optional): If set to True, then output tokens will
             be diacritized, otherwise they will be undiacritized.
             Defaults to False.
+            Note that when the tokenization scheme is set to 'bwtok', the
+            number of produced undiacritized tokens might be less than the
+            diacritized tokens becuase the 'bwtok' scheme can have
+            morphemes that are standalone diacritics (e.g. case and mood).
     """
 
     def __init__(self, disambiguator, scheme='atbtok', split=False,

--- a/camel_tools/tokenizers/morphological.py
+++ b/camel_tools/tokenizers/morphological.py
@@ -27,12 +27,35 @@
 """
 
 
+import re
 from collections import deque
 from camel_tools.utils.dediac import dediac_ar
 
 
-_SCHEME_SET = frozenset(['atbtok', 'atbseg', 'd1tok', 'd1seg', 'd2tok',
+# Reduce consequitive '+'s to one
+_REMOVE_PLUSES = re.compile(r'(_\+|\+_)+')
+
+_SCHEME_SET = frozenset(['atbtok', 'atbseg', 'bwtok', 'd1tok', 'd1seg', 'd2tok',
                          'd2seg', 'd3tok', 'd3seg'])
+
+def _default_dediac(tok):
+    return dediac_ar(tok)
+
+
+def _special_dediac(tok):
+    return _REMOVE_PLUSES.sub(r'\g<1>', dediac_ar(tok).strip('+_'))
+
+_DIAC_TYPE = {
+    'atbtok': _default_dediac,
+    'atbseg': _default_dediac,
+    'bwtok': _special_dediac,
+    'd1tok': _default_dediac,
+    'd1seg': _default_dediac,
+    'd2tok': _default_dediac,
+    'd2seg': _default_dediac,
+    'd3tok': _default_dediac,
+    'd3seg': _default_dediac
+}
 
 
 class MorphologicalTokenizer(object):
@@ -58,7 +81,7 @@ class MorphologicalTokenizer(object):
         self._disambiguator = disambiguator
         self._scheme = scheme
         self._split = split
-        self._diacf = lambda w: w if diac else dediac_ar(w)
+        self._diacf = lambda w: w if diac else _DIAC_TYPE[self._scheme](w)
 
     @classmethod
     def scheme_set(cls):
@@ -93,7 +116,8 @@ class MorphologicalTokenizer(object):
                     tok = disambig_word.word
                     result.append(self._diacf(tok))
                 elif self._split:
-                    result.extend(self._diacf(t) for t in tok.split('_'))
+                    tok = self._diacf(tok)
+                    result.extend(tok.split('_'))
                 else:
                     result.append(self._diacf(tok))
 

--- a/docs/source/api/tagger/default.rst
+++ b/docs/source/api/tagger/default.rst
@@ -27,9 +27,10 @@ The list of features that can be produced by :obj:`DefaultTagger` are:
 :code:`'mod'`, :code:`'num'`, :code:`'per'`, :code:`'pos'`, :code:`'enc0'`,
 :code:`'enc1'`, :code:`'enc2'`, :code:`'prc0'`, :code:`'prc1'`, :code:`'prc2'`,
 :code:`'prc3'`, :code:`'form_num'`, :code:`'form_gen'`, :code:`'stt'`,
-:code:`'vox'`, :code:`'atbtok'`, :code:`'atbseg'`, :code:`'d1tok'`,
-:code:`'d1seg'`, :code:`'d2tok'`, :code:`'d2seg'`, :code:`'d3tok'`,
-:code:`'d3seg'`, :code:`'catib6'`, :code:`'ud'`, :code:`'caphi'`.
+:code:`'vox'`, :code:`'atbtok'`, :code:`'atbseg'`, :code:`bwtok`,
+:code:`'d1tok'`, :code:`'d1seg'`, :code:`'d2tok'`, :code:`'d2seg'`,
+:code:`'d3tok'`, :code:`'d3seg'`, :code:`'catib6'`, :code:`'ud'`,
+:code:`'caphi'`.
 
 See See :doc:`/reference/camel_morphology_features` for more information on
 features and their values.

--- a/docs/source/reference/camel_morphology_features.rst
+++ b/docs/source/reference/camel_morphology_features.rst
@@ -253,6 +253,7 @@ Lexical Features
 * **root** - Traditional Arabic root consonants
 * **atbtok** - ATB tokenization
 * **d3tok** - D3 tokenization
+* **bwtok** - Buckwalter POS tag based tokenization
 
 .. * **atbseg** - ATB segmentation
 .. * **d1tok** - D1 tokenization


### PR DESCRIPTION
A Buckwalter POS tag based tokenization: `bwtok` is now being produced as part of the morphological analyses.
`bwtok` can also be produced through the morphological tokenizer API.