### PR TITLE
Enforcing sentencepiece version to be 0.1.91

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ INSTALL_REQUIRES = [
     'transformers==3.0.2',
     'editdistance',
     'requests',
+    'sentencepiece==0.1.91',
 ]
 
 INSTALL_REQUIRES_NOT_WINDOWS = [


### PR DESCRIPTION
The latest sentence piece version generates errors when installed.