### PR TITLE
Segmentation features are now part of the rewrite rules

### DIFF
--- a/camel_tools/morphology/utils.py
+++ b/camel_tools/morphology/utils.py
@@ -35,11 +35,13 @@ _CONCAT_FEATS_NONE = frozenset(['d3tok', 'd3seg', 'atbseg', 'd2seg', 'd1seg',
                                 'd1tok', 'd2tok', 'atbtok', 'bwtok'])
 _LOGPROB_FEATS = frozenset(['pos_logprob', 'lex_logprob', 'pos_lex_logprob'])
 
-# Tokenization schemes to which Sun letters and Fatha after Alif rewrite
-# rules apply
-_TOK_SCHEMES_1 = frozenset(['d1tok', 'd2tok', 'atbtok'])
-# Tokenization schemes to which only the Fatha after Alif rewrite rule apply
-_TOK_SCHEMES_2 = frozenset(['d3tok'])
+# Tokenization and segmentation schemes to which Sun letters and Fatha after 
+# Alif rewrite rules apply
+_TOK_SCHEMES_1 = frozenset(['d1tok', 'd2tok', 'atbtok', 'd1seg', 'd2seg',
+                            'd3seg', 'atbseg'])
+# Tokenization and segmentation schemes to which only the Fatha after Alif 
+# rewrite rule apply
+_TOK_SCHEMES_2 = frozenset(['d3tok', 'd3seg'])
 
 # Sun letters with definite article
 _REWRITE_DIAC_RE_1 = re.compile(u'#\\+*([\u062a\u062b\u062f\u0630\u0631\u0632'


### PR DESCRIPTION
This PR is in parallel with the latest segmentation features fixes in the `calima-msa-db 0.3.0`. 