### PR TITLE
Allow unicode range up to 0x110000

### DIFF
--- a/camel_tools/utils/charsets.py
+++ b/camel_tools/utils/charsets.py
@@ -32,21 +32,21 @@ from six import unichr
 
 
 UNICODE_PUNCT_CHARSET = frozenset(
-    [unichr(x) for x in range(65536) if unicodedata.category(
+    [unichr(x) for x in range(0x110000) if unicodedata.category(
         unichr(x))[0] == 'P'])
 UNICODE_SYMBOL_CHARSET = frozenset(
-    [unichr(x) for x in range(65536) if unicodedata.category(
+    [unichr(x) for x in range(0x110000) if unicodedata.category(
         unichr(x))[0] == 'S'])
 UNICODE_PUNCT_SYMBOL_CHARSET = UNICODE_PUNCT_CHARSET | UNICODE_SYMBOL_CHARSET
 
 UNICODE_LETTER_CHARSET = frozenset(
-    [unichr(x) for x in range(65536) if unicodedata.category(
+    [unichr(x) for x in range(0x110000) if unicodedata.category(
         unichr(x))[0] == 'L'])
 UNICODE_MARK_CHARSET = frozenset(
-    [unichr(x) for x in range(65536) if unicodedata.category(
+    [unichr(x) for x in range(0x110000) if unicodedata.category(
         unichr(x))[0] == 'M'])
 UNICODE_NUMBER_CHARSET = frozenset(
-    [unichr(x) for x in range(65536) if unicodedata.category(
+    [unichr(x) for x in range(0x110000) if unicodedata.category(
         unichr(x))[0] == 'N'])
 UNICODE_LETTER_MARK_NUMBER_CHARSET = (UNICODE_LETTER_CHARSET |
                                       UNICODE_MARK_CHARSET |


### PR DESCRIPTION
- Fix the issue of `simple_word_tokenize` that removes Emoijs.
- Change the maximum Unicode point from `65536 ` to `0x110000` (`1114112` in decimal).