### PR TITLE
Subtract 1e-15 from backoff analysis score

### DIFF
--- a/camel_tools/disambig/score_function.py
+++ b/camel_tools/disambig/score_function.py
@@ -78,6 +78,9 @@ def score_analysis_uniform(analysis, reference, mle_model=None,
 
     if tie_breaker == 'tag':
         score += _tie_breaker_tag(analysis, reference, mle_model)
+    
+    if analysis['source'] == 'backoff':
+        score -= 1e-15
 
     return score
 


### PR DESCRIPTION
This pull request deals with the issue of a backoff analysis getting the same score as the actual analysis.