### PR TITLE
Sort by lex probability

### DIFF
--- a/camel_tools/disambig/bert/unfactored.py
+++ b/camel_tools/disambig/bert/unfactored.py
@@ -464,7 +464,12 @@ class BERTUnfactoredDisambiguator(Disambiguator):
                                 tie_breaker=self._tie_breaker,
                                 features=self._features), a)
                   for a in analyses]
-        scored.sort(key=lambda s: (-s[0], s[1]['diac']))
+
+        if 'lex_logprob' in scored[0][1]:
+            scored.sort(key=lambda s: (-s[0], s[1]['diac'],
+                                       -s[1]['lex_logprob']))
+        else:
+            scored.sort(key=lambda s: (-s[0], s[1]['diac']))
 
         max_score = max(s[0] for s in scored)
 


### PR DESCRIPTION
This pull request improves the sorting function for the BERT disambiguation component in MSA and EGY.

We first sort analyses by their scores, alphabetically in `diac`, and then by `lex_logprob`. The difference from the previous approach is additional sorting by `lex_logprob`. Currently, it only works with MSA and EGY databases, because the `lex_logprob` feature is missing in GLF and LEV databases.