### PR TITLE
Fixed missing diac error.

### DIFF
--- a/camel_tools/disambig/bert/unfactored.py
+++ b/camel_tools/disambig/bert/unfactored.py
@@ -470,7 +470,7 @@ class BERTUnfactoredDisambiguator(Disambiguator):
             # return the predictions from BERT
             return [ScoredAnalysis(0,                      # score
                                    bert_analysis,          # analysis
-                                   bert_analysis['diac'],  # diac
+                                   word_dd,                # diac
                                    -99,                    # pos_lex_logprob
                                    -99,                    # lex_logprob
                                    )]


### PR DESCRIPTION
- Fixed the error that occurs when the word is not found in the analyzer where it tries to find its `diac` feature from the BERT predictions, which does not exist.
- We use dediacritized words for those unknown words.