### PR TITLE
Updated test cases.

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -32,7 +32,7 @@ from __future__ import absolute_import, print_function
 import os
 
 import camel_tools as camelt
-from camel_tools.cli import camel_calima_star
+from camel_tools.cli import camel_morphology
 from camel_tools.cli import camel_transliterate
 from camel_tools.cli import camel_arclean
 
@@ -49,6 +49,6 @@ def test_camel_tools_version():
 
     assert(VERSION ==
            camelt.__version__ ==
-           camel_calima_star.__version__ ==
+           camel_morphology.__version__ ==
            camel_transliterate.__version__ ==
            camel_arclean.__version__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39
+envlist = py39, py310
 
 [testenv]
 changedir = tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310
+envlist = py39, py310, 311, 312
 
 [testenv]
 changedir = tests


### PR DESCRIPTION
Updated versions we test on (currently 3.9-3.10), and renamed a camel_calima_star to camel_morphology when checking versions (was renamed previously).
Tests pass.