### PR TITLE
  Fix CAPHI rewrite rules, source feature clobbering, and MLEDisambiguator top=-1 support     

### DIFF
--- a/camel_tools/disambig/mle.py
+++ b/camel_tools/disambig/mle.py
@@ -103,7 +103,7 @@ class MLEDisambiguator(Disambiguator):
             then no word-based MLE lookup is performed skipping directly to
             using the pos-lex model. Defaults to `None`.
         top (:obj:`int`, optional): The maximum number of top analyses to
-            return. Defaults to 1.
+            return. Set to -1 to return all analyses. Defaults to 1.
         cache_size (:obj:`int`, optional): The number of unique word
             disambiguations to cache. The cache uses a least-frequently-used
             eviction policy. Defaults to 100000.
@@ -129,7 +129,7 @@ class MLEDisambiguator(Disambiguator):
 
         self._analyzer = analyzer
 
-        if top < 1:
+        if top != -1 and top < 1:
             top = 1
         self._top = top
 
@@ -155,7 +155,7 @@ class MLEDisambiguator(Disambiguator):
                 analyzer to use. If None, an instance of the model's default
                 analyzer is created. Defaults to None.
             top (:obj:`int`, optional): The maximum number of top analyses to
-                return. Defaults to 1.
+                return. Set to -1 to return all analyses. Defaults to 1.
             cache_size (:obj:`int`, optional): The number of unique word
                 disambiguations to cache. The cache uses a
                 least-frequently-used eviction policy. Defaults to 100000.
@@ -200,6 +200,8 @@ class MLEDisambiguator(Disambiguator):
                     a.get('lex_logprob', -99),      # lex_logprob
                 ) for s, a in scored]
 
+            if self._top == -1:
+                return scored_analyses
             return scored_analyses[0:self._top]
 
         else:
@@ -222,6 +224,8 @@ class MLEDisambiguator(Disambiguator):
 
             scored_analyses.sort()
 
+            if self._top == -1:
+                return scored_analyses
             return scored_analyses[0:self._top]
         
     def _scored_analyses_cached(self, word_dd):

--- a/camel_tools/morphology/utils.py
+++ b/camel_tools/morphology/utils.py
@@ -71,9 +71,9 @@ _REWRITE_CAPHI_RE_1 = re.compile(u'(l-)\\+(t\\_|th\\_|d\\_|th\\.\\_|r\\_|z\\_|'
 # Replace shadda
 _REWRITE_CAPHI_RE_2 = re.compile(u'(\\S)[-]*\\+~')
 # Replace ending i_y with ii if suffix is not a vowel
-_REWRITE_CAPHI_RE_3 = re.compile(u'i\\_y-\\+([^iau]+|$)')
+_REWRITE_CAPHI_RE_3 = re.compile(u'i\\_y-(\\+[^iau]+|$)')
 # Replacing ending u_w with uu if suffix is not a vowel
-_REWRITE_CAPHI_RE_4 = re.compile(u'u\\_w-\\+([^iau]+|$)')
+_REWRITE_CAPHI_RE_4 = re.compile(u'u\\_w-(\\+[^iau]+|$)')
 # Remove hamza wasl if preceeded by a vowel
 _REWRITE_CAPHI_RE_5 = re.compile(u'([iua])\\+-2_[iua]')
 # Remove hamza wasl if preceeded by a non-vowel
@@ -217,6 +217,8 @@ def merge_features(db, prefix_feats, stem_feats, suffix_feats, diac_mode="AF"):
     result = copy.copy(stem_feats)
 
     for stem_feat in stem_feats:
+        if stem_feat == 'source':
+            continue
         suffix_feat_val = suffix_feats.get(stem_feat, '')
         if suffix_feat_val != '-' and suffix_feat_val != '':
             result[stem_feat] = suffix_feat_val


### PR DESCRIPTION
                                                                                                                                                                                                         
  This PR fixes three independent bugs reported in the issue tracker:                                                                                                                                                                                         
  - **Fix #138 — Broken CAPHI rewrite rules at word boundary**
    `_REWRITE_CAPHI_RE_3` and `_REWRITE_CAPHI_RE_4` in `utils.py` required a                                                                                                                      
    literal `+` morpheme separator before matching, so they never fired at  
    word boundaries (where no `+` is present). Moved the `+` inside the                                                                                                                           
    alternation group so both `+non-vowel` and end-of-string are handled                                                                                                                          
    correctly. The same structural bug affected both regexes, so both are fixed.                                                                                                                  
                                                                                                                                                                                                  
  - **Fix #139 — `source` feature overwritten by suffix in `merge_features()`**                                                                                                                   
    The loop that copies non-empty suffix features onto the stem result was                                                                                                                       
    unconditionally overwriting `source` (e.g. `source:wiki` from a suffix                                                                                                                        
    clobbering `source:lex` from the stem). Added a `continue` guard to skip                                                                                                                      
    the `source` key during suffix merging.                                                                                                                                                       
                                                                                                                                                                                                  
  - **Fix #50 — `MLEDisambiguator` silently clamped `top < 1` to `1`**                                                                                                                            
    Users had no way to retrieve all analyses without guessing a large number.                                                                                                                    
    `top=-1` is now accepted as a sentinel to return all scored analyses.     
    Updated docstrings for both `__init__` and `pretrained`.                                                                                                                                      
                                                                                                                                                                                                  
  ## Files changed                                                                                                                                                                                
                                                                                                                                                                                                  
  - `camel_tools/morphology/utils.py`                                                                                                                                                             
  - `camel_tools/disambig/mle.py`                                                                                                                                                                 
                                 
  ## Test plan
                                                                                                                                                                                                  
  - [ ] Verify CAPHI output for a word-final `u_w` stem (e.g. a verb with no
        vowel suffix) now produces `uu` instead of being left unrewritten                                                                                                                         
  - [ ] Verify that an entry with `source:wiki` on a suffix no longer    
        overwrites a stem's `source:lex`                                                                                                                                                          
  - [ ] Verify `MLEDisambiguator(analyzer, top=-1).disambiguate(sentence)`                                                                                                                        
        returns all analyses for each word instead of just the top 1  