### PR TITLE
Bert clips text when word is unknown token

### DIFF
--- a/camel_tools/disambig/bert/_bert_morph_dataset.py
+++ b/camel_tools/disambig/bert/_bert_morph_dataset.py
@@ -140,21 +140,19 @@ class MorphDataset(Dataset):
             label_ids = []
 
             for word, label in zip(sentence.words, sentence.labels):
+                if word is None or word.strip() == "":
+                    continue  # skip empty or whitespace words and do not add them to the tokens and label_ids lists
                 word_tokens = tokenizer.tokenize(word)
-                # if word_tokens ==[]:
-                # If the word is not in the vocabulary, we use the
-                # [UNK] token to represent it.
+                # If the word is not in the vocabulary, we use the [UNK] token to represent it.
                 if not word_tokens or all(token == tokenizer.unk_token for token in word_tokens):
                     # word_tokens = ['[UNK]']
                     # Use the [UNK] label id for the unknown word
                     word_tokens = [tokenizer.unk_token]
-                # bert-base-multilingual-cased sometimes output "nothing ([])
-                # when calling tokenize with just a space.
-                if len(word_tokens) > 0:
-                    tokens.append(word_tokens)
-                    # Use the real label id for the first token of the word,
-                    # and padding ids for the remaining tokens
-                    label_ids.append([label_map[label]] +
+
+                tokens.append(word_tokens)
+                # Use the real label id for the first token of the word,
+                # and padding ids for the remaining tokens
+                label_ids.append([label_map[label]] +
                                      [pad_token_label_id] *
                                      (len(word_tokens) - 1))
 

--- a/camel_tools/disambig/bert/_bert_morph_dataset.py
+++ b/camel_tools/disambig/bert/_bert_morph_dataset.py
@@ -141,6 +141,13 @@ class MorphDataset(Dataset):
 
             for word, label in zip(sentence.words, sentence.labels):
                 word_tokens = tokenizer.tokenize(word)
+                # if word_tokens ==[]:
+                # If the word is not in the vocabulary, we use the
+                # [UNK] token to represent it.
+                if not word_tokens or all(token == tokenizer.unk_token for token in word_tokens):
+                    # word_tokens = ['[UNK]']
+                    # Use the [UNK] label id for the unknown word
+                    word_tokens = [tokenizer.unk_token]
                 # bert-base-multilingual-cased sometimes output "nothing ([])
                 # when calling tokenize with just a space.
                 if len(word_tokens) > 0:


### PR DESCRIPTION
fix [BUG] BERTUnfactoredDisambiguator.pretrained() clips text when special character � exists #159

when bert tokanizer does not recognize the word it return [] which result in clip text.

such as when sentence contains  special character � (or any unrecognised  word) it will then clips last tokens of text.